### PR TITLE
Translation related issues solved

### DIFF
--- a/app/code/community/ProxiBlue/ReCaptcha/etc/config.xml
+++ b/app/code/community/ProxiBlue/ReCaptcha/etc/config.xml
@@ -56,6 +56,12 @@
                         <default>ProxiBlue_ReCaptcha.csv</default>
                     </files>
                 </ProxiBlue_ReCaptcha>
+                <!-- Magento forgot to add this to Mage_Captcha's config.xml -->
+                <Mage_Captcha>
+                    <files>
+                        <default>Mage_Captcha.csv</default>
+                    </files>
+                </Mage_Captcha>
             </modules>
         </translate>
     </adminhtml>
@@ -74,6 +80,12 @@
                         <default>ProxiBlue_ReCaptcha.csv</default>
                     </files>
                 </ProxiBlue_ReCaptcha>
+                <!-- Magento forgot to add this to Mage_Captcha's config.xml -->
+                <Mage_Captcha>
+                    <files>
+                        <default>Mage_Captcha.csv</default>
+                    </files>
+                </Mage_Captcha>
             </modules>
         </translate>
     </frontend>

--- a/app/code/community/ProxiBlue/ReCaptcha/etc/config.xml
+++ b/app/code/community/ProxiBlue/ReCaptcha/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <ProxiBlue_ReCaptcha>
-            <version>1.4.0</version>
+            <version>1.4.1</version>
             <depends>
                 <Mage_Captcha/>
             </depends>

--- a/app/code/community/ProxiBlue/ReCaptcha/etc/system.xml
+++ b/app/code/community/ProxiBlue/ReCaptcha/etc/system.xml
@@ -72,6 +72,7 @@
 		<customer>
 			<groups>
 				<captcha translate="label">
+                    <show_in_store>1</show_in_store>
 					<fields>
 						<font>
 							<depends>

--- a/app/etc/modules/ProxiBlue_ReCaptcha.xml
+++ b/app/etc/modules/ProxiBlue_ReCaptcha.xml
@@ -4,7 +4,9 @@
         <ProxiBlue_ReCaptcha>
             <active>true</active>
             <codePool>community</codePool>
-            <depends></depends>
+            <depends>
+                <Mage_Captcha/>
+            </depends>
         </ProxiBlue_ReCaptcha>
     </modules>
 </config>


### PR DESCRIPTION
- Magento forgot to define the `Mage_Captcha.csv` translation file in `config.xml`, so I added it in this module
- Made the Captcha group for _Customers » Customer Configuration_ visible on store view level to be able to change the language on store view level (which is exactly what store views are usually used for)
- Made the module dependent on `Mage_Captcha`. To reflect reality; it *is* dependent, but also to make sure that the module's config is parsed _after_ `Mage_Captcha`'s
- Because the module is not that active, I also already added the version bump as a separate commit