### PR TITLE
Prevent reCaptcha overlapping content

### DIFF
--- a/app/design/adminhtml/default/default/template/captcha/recaptcha.phtml
+++ b/app/design/adminhtml/default/default/template/captcha/recaptcha.phtml
@@ -50,7 +50,7 @@
             });
         };
     </script>
-    <div id="recaptcha_html_element"></div>
+    <div id="recaptcha_html_element" style="clear: both"></div>
     <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit&hl=<?php echo $captcha->getLanguage(); ?>" async defer></script>
 <?php else: ?>
     <script type="text/javascript">


### PR DESCRIPTION
Added "clear: both" styling to recaptcha_html_element to stop it overlapping content (in particular, the admin "Forgotten Password" link when CAPTCHA enabled in Admin)