### PR TITLE
Correct default theme and position

### DIFF
--- a/app/code/community/ProxiBlue/ReCaptcha/Model/Recaptcha.php
+++ b/app/code/community/ProxiBlue/ReCaptcha/Model/Recaptcha.php
@@ -35,7 +35,7 @@ class ProxiBlue_ReCaptcha_Model_Recaptcha extends Mage_Captcha_Model_Zend implem
     protected $_theme = 'invisible';
     protected $_private_key = null;
     protected $_public_key = null;
-    protected $_position = 'bottomleft';
+    protected $_position = 'bottomright';
 
 
     /**

--- a/app/code/community/ProxiBlue/ReCaptcha/etc/config.xml
+++ b/app/code/community/ProxiBlue/ReCaptcha/etc/config.xml
@@ -109,7 +109,8 @@
         <customer>
             <captcha>
                 <type>recaptcha</type>
-                <theme>New</theme>
+                <theme>invisible</theme>
+                <position>bottomright</position>
                 <language>en</language>
                 <mode>always</mode>
             </captcha>


### PR DESCRIPTION
The default values of `customer/captcha/theme` and `customer/captcha/position` are set
to the first value of the corresponding source models such that the default values
are the same as the default values that are shown in the system configuration.

This resolves issues when using the module without ever saving the settings from the admin system configuration (e.g. when only changes to the default settings are made via `app/etc/local.xml` or a data upgrade script). In our case, the I'm not a Robot ReCAPTCHA was shown instead of the invisible ReCAPTCHA.