### PR TITLE
Fixes bug in Firecheckout when editing

### DIFF
--- a/app/design/frontend/base/default/template/captcha/recaptcha.phtml
+++ b/app/design/frontend/base/default/template/captcha/recaptcha.phtml
@@ -87,9 +87,12 @@
                 <?php $handle = $this->getLayout()->getUpdate()->getHandles(); ?>
                 
                 <?php if(in_array('firecheckout_index_index', $handle)): ?>
-                document.observe('firecheckout:updateBefore', function(url, parameters) {
-                grecaptcha.execute();
-                });
+                    document.observe('firecheckout:updateBefore', function(url, parameters) {
+                        window.captchas.forEach(function (id) {
+                            grecaptcha.reset(id);
+                        });
+                        grecaptcha.execute();
+                    });
                 <?php endif;?>
                 
                 <?php if(in_array('checkout_onepage_index', $handle)): ?>


### PR DESCRIPTION
In firecheckout (TM_Firecheckout), when coming back to a previous section to edit some wrong information, the captcha wasn't updated properly.
The solution was given by @ProxiBlue . I just tested and confirmed it works.