### PR TITLE
Supports CURL for google recaptcha requests

### DIFF
--- a/app/code/community/ProxiBlue/ReCaptcha/Model/Config/Adapter.php
+++ b/app/code/community/ProxiBlue/ReCaptcha/Model/Config/Adapter.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Captcha adapter type model
+ *
+ * @category   ProxiBlue
+ * @package    ProxiBlue_reCaptcha
+ * @author     Lucas van Staden (sales@proxiblue.com.au)
+ */
+class ProxiBlue_ReCaptcha_Model_Config_Adapter {
+
+    public function toOptionArray()
+    {
+        return array(
+            array('value' => 'Zend_Http_Client_Adapter_Socket', 'label' => 'Socket (default)'),
+            array('value' => 'Zend_Http_Client_Adapter_Curl', 'label' => 'curl'),
+        );
+    }
+
+}

--- a/app/code/community/ProxiBlue/ReCaptcha/Model/Recaptcha.php
+++ b/app/code/community/ProxiBlue/ReCaptcha/Model/Recaptcha.php
@@ -165,6 +165,7 @@ class ProxiBlue_ReCaptcha_Model_Recaptcha extends Mage_Captcha_Model_Zend implem
             . '/'
             . $path
         );
+        $httpRequest->setAdapter('Zend_Http_Client_Adapter_Curl');
         $httpRequest->setParameterPost(array_merge(array('remoteip' => $_SERVER['REMOTE_ADDR']), $params));
         $response = $httpRequest->request('POST');
         if ($response->getStatus() != 200) {

--- a/app/code/community/ProxiBlue/ReCaptcha/Model/Recaptcha.php
+++ b/app/code/community/ProxiBlue/ReCaptcha/Model/Recaptcha.php
@@ -36,6 +36,7 @@ class ProxiBlue_ReCaptcha_Model_Recaptcha extends Mage_Captcha_Model_Zend implem
     protected $_private_key = null;
     protected $_public_key = null;
     protected $_position = 'bottomright';
+    protected $_adapter = 'Zend_Http_Client_Adapter_Socket';
     protected $_originalFormId = '';
     protected $_forms = [];
 
@@ -71,6 +72,7 @@ class ProxiBlue_ReCaptcha_Model_Recaptcha extends Mage_Captcha_Model_Zend implem
         $this->_private_key = $this->_getHelper()->getConfigNode('private_key');
         $this->_public_key = $this->_getHelper()->getConfigNode('public_key');
         $this->_position = $this->_getHelper()->getConfigNode('position');
+        $this->_adapter = $this->_getHelper()->getConfigNode('adapter');
         $this->_debugEnabled = Mage::getStoreConfigFlag('customer/captcha/debug');
     }
 
@@ -97,6 +99,11 @@ class ProxiBlue_ReCaptcha_Model_Recaptcha extends Mage_Captcha_Model_Zend implem
     public function getPublicKey()
     {
         return $this->_public_key;
+    }
+
+    public function getAdapter()
+    {
+        return $this->_adapter;
     }
 
     public function isCorrect($word)
@@ -165,7 +172,7 @@ class ProxiBlue_ReCaptcha_Model_Recaptcha extends Mage_Captcha_Model_Zend implem
             . '/'
             . $path
         );
-        $httpRequest->setAdapter('Zend_Http_Client_Adapter_Curl');
+        $httpRequest->setAdapter($this->getAdapter());
         $httpRequest->setParameterPost(array_merge(array('remoteip' => $_SERVER['REMOTE_ADDR']), $params));
         $response = $httpRequest->request('POST');
         if ($response->getStatus() != 200) {

--- a/app/code/community/ProxiBlue/ReCaptcha/etc/config.xml
+++ b/app/code/community/ProxiBlue/ReCaptcha/etc/config.xml
@@ -132,6 +132,7 @@
                 <theme>invisible</theme>
                 <position>bottomright</position>
                 <language>en</language>
+                <adapter>Zend_Http_Client_Adapter_Socket</adapter>
                 <mode>always</mode>
                 <always_for>
                     <user_create>1</user_create>

--- a/app/code/community/ProxiBlue/ReCaptcha/etc/system.xml
+++ b/app/code/community/ProxiBlue/ReCaptcha/etc/system.xml
@@ -90,6 +90,16 @@
 							<show_in_store>1</show_in_store>
 							<depends><enable>1</enable><type>recaptcha</type></depends>
 						</language>
+						<adapter translate="label">
+							<label>Adapter</label>
+							<frontend_type>select</frontend_type>
+							<source_model>proxiblue_recaptcha/config_adapter</source_model>
+							<sort_order>12</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<depends><enable>1</enable><type>recaptcha</type></depends>
+						</adapter>
 					</fields>
 				</captcha>
 			</groups>
@@ -192,6 +202,16 @@
 							<show_in_website>1</show_in_website>
 							<show_in_store>1</show_in_store>
 						</debug>
+						<adapter translate="label">
+							<label>Adapter</label>
+							<frontend_type>select</frontend_type>
+							<source_model>proxiblue_recaptcha/config_adapter</source_model>
+							<sort_order>12</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<depends><enable>1</enable><type>recaptcha</type></depends>
+						</adapter>
 					</fields>
 				</captcha>
 			</groups>


### PR DESCRIPTION
Had a problem on magento 1.9 where google wouldn't connect using the standard Zend_Http_Client. Setting this adapter allows the request to go through.